### PR TITLE
[Do not merge] Improve message for sets with one date

### DIFF
--- a/src/PackagePrivate/PrivateStructuredHumanizer.php
+++ b/src/PackagePrivate/PrivateStructuredHumanizer.php
@@ -62,6 +62,10 @@ class PrivateStructuredHumanizer implements StructuredHumanizer {
 	}
 
 	private function humanizeSetDatesToSingleMessage( HumanizedSetDates $humanizedDates, bool $isAllMembers ): string {
+		if ( count( $humanizedDates->humanizedDates ) === 1 ) {
+			return $humanizedDates->humanizedDates[0];
+		}
+
 		if ( count( $humanizedDates->humanizedDates ) === 2 ) {
 			if ( $isAllMembers ) {
 				return $humanizedDates->humanizedDates[0] . ' and ' . $humanizedDates->humanizedDates[1]; // TODO i18n

--- a/tests/Unit/PackagePrivate/PrivateStructuredHumanizerTest.php
+++ b/tests/Unit/PackagePrivate/PrivateStructuredHumanizerTest.php
@@ -191,4 +191,20 @@ class PrivateStructuredHumanizerTest extends TestCase {
 		);
 	}
 
+	public function testSetWithSingleDate(): void {
+		$set = new Set(
+			[
+				new Season( 2021, 21 ),
+			],
+			false,
+			false,
+			false
+		);
+
+		$this->assertHumanizedToSingleMessage(
+			'Spring 2021',
+			$this->humanize( $set )
+		);
+	}
+
 }


### PR DESCRIPTION
Actually not sure this is a good change.

@mzeinstra what do you prefer for `[2020]`? `2020` or `One of these dates: 2020`