### PR TITLE
Add an ISO 8601 helper function

### DIFF
--- a/src/Model/ExtDate.php
+++ b/src/Model/ExtDate.php
@@ -350,14 +350,14 @@ class ExtDate implements EdtfValue, HasPrecision
     {
         $iso = '';
         if ($this->year) {
-			$iso = strval($this->year);
+            $iso = strval($this->year);
             if ($this->month) {
                 $iso .= '-' . sprintf("%02s", $this->month);
                 if ($this->day) {
                     $iso .= '-' . sprintf("%02s", $this->day);
                 }
             }
-		}
+        }
 
         return $iso;
     }

--- a/src/Model/ExtDate.php
+++ b/src/Model/ExtDate.php
@@ -345,4 +345,20 @@ class ExtDate implements EdtfValue, HasPrecision
 
 		return '';
 	}
+
+    public function iso8601(): string
+    {
+        $iso = '';
+        if ($this->year) {
+			$iso = strval($this->year);
+            if ($this->month) {
+                $iso .= '-' . sprintf("%02s", $this->month);
+                if ($this->day) {
+                    $iso .= '-' . sprintf("%02s", $this->day);
+                }
+            }
+		}
+
+        return $iso;
+    }
 }

--- a/src/Model/ExtDateTime.php
+++ b/src/Model/ExtDateTime.php
@@ -129,12 +129,19 @@ class ExtDateTime implements EdtfValue
         $date = new \DateTime();
         $date->setDate($this->getYear(), $this->getMonth(), $this->getDay());
         $date->setTime($this->getHour(), $this->getMinute(), $this->getSecond());
-        try {
+
+        // The hour, minute, and second are stored as given, but adding the timezone
+        // on to the DateTime will shift the time, so we need to pull it back off.
+        if (!is_null($this->timezoneOffset)) {
+            if($this->timezoneOffset > 0 ) {
+                $date->sub(new \DateInterval('PT' . $this->timezoneOffset . 'M'));
+            } else {
+                $date->add(new \DateInterval('PT' . abs($this->timezoneOffset) . 'M'));
+            }
             $date->setTimezone(new \DateTimeZone($this->getTzSign() . sprintf("%02s:%02s", $this->getTzHour(), $this->getTzMinute())));
-        } catch (\Exception $e) {
-            // Timezone probably not provided. Swallow the exception.
+            return $date->format('c');
         }
         
-        return $date->format('c');
+        return $date->format('Y-m-d\Th:i:s');
     }
 }

--- a/src/Model/ExtDateTime.php
+++ b/src/Model/ExtDateTime.php
@@ -124,16 +124,17 @@ class ExtDateTime implements EdtfValue
 		return $this->date;
 	}
 
-	public function iso8601(): string {
-		$date = new \DateTime();
-		$date->setDate($this->getYear(), $this->getMonth(), $this->getDay());
-		$date->setTime($this->getHour(), $this->getMinute(), $this->getSecond());
-		try {
-			$date->setTimezone(new \DateTimeZone($this->getTzSign() . sprintf("%02s:%02s", $this->getTzHour(), $this->getTzMinute())));
-		} catch (\Exception $e) {
-			// Timezone probably not provided. Swallow the exception.
-		}
-		
-		return $date->format('c');
-	}
+    public function iso8601(): string
+    {
+        $date = new \DateTime();
+        $date->setDate($this->getYear(), $this->getMonth(), $this->getDay());
+        $date->setTime($this->getHour(), $this->getMinute(), $this->getSecond());
+        try {
+            $date->setTimezone(new \DateTimeZone($this->getTzSign() . sprintf("%02s:%02s", $this->getTzHour(), $this->getTzMinute())));
+        } catch (\Exception $e) {
+            // Timezone probably not provided. Swallow the exception.
+        }
+        
+        return $date->format('c');
+    }
 }

--- a/src/Model/ExtDateTime.php
+++ b/src/Model/ExtDateTime.php
@@ -124,4 +124,16 @@ class ExtDateTime implements EdtfValue
 		return $this->date;
 	}
 
+	public function iso8601(): string {
+		$date = new \DateTime();
+		$date->setDate($this->getYear(), $this->getMonth(), $this->getDay());
+		$date->setTime($this->getHour(), $this->getMinute(), $this->getSecond());
+		try {
+			$date->setTimezone(new \DateTimeZone($this->getTzSign() . sprintf("%02s:%02s", $this->getTzHour(), $this->getTzMinute())));
+		} catch (\Exception $e) {
+			// Timezone probably not provided. Swallow the exception.
+		}
+		
+		return $date->format('c');
+	}
 }

--- a/tests/Unit/Model/ExtDateTest.php
+++ b/tests/Unit/Model/ExtDateTest.php
@@ -158,6 +158,14 @@ class ExtDateTest extends TestCase
 		$this->assertEquals($expectedPrecisionString, $edtf->precisionAsString());
 	}
 
+    /**
+     * @dataProvider isoDateProvider
+     */
+    public function testIsoDate(ExtDate $edtf, string $expectedIsoString): void
+    {
+        $this->assertEquals($expectedIsoString, $edtf->iso8601());
+    }
+
     public function datePrecisionProvider(): array
 	{
 		return [
@@ -201,6 +209,34 @@ class ExtDateTest extends TestCase
                 new ExtDate(1987, 2),
                 $daysInMonth = Carbon::create(1987, 2)->lastOfMonth()->endOfDay()->timestamp
             ]
+        ];
+    }
+
+    public function isoDateProvider(): array
+    {
+        return [
+            [
+                new ExtDate(1987),
+                '1987'
+            ],
+            [
+                new ExtDate(1987, 10),
+                '1987-10'
+            ],
+            [
+                new ExtDate(1987, 10, 1),
+                '1987-10-01'
+            ],
+            [
+                new ExtDate(
+                    1987, 10, 1, 
+                    new Qualification(
+                        Qualification::UNDEFINED, 
+                        Qualification::APPROXIMATE
+                    )
+                ),
+                '1987-10-01'
+            ],
         ];
     }
 }

--- a/tests/Unit/Model/ExtDateTimeTest.php
+++ b/tests/Unit/Model/ExtDateTimeTest.php
@@ -67,4 +67,22 @@ class ExtDateTimeTest extends TestCase
         $this->assertSame(10, $date->getSecond());
         $this->assertSame(300, $date->getTimezoneOffset());
     }
+
+    public function testIsoDate(): void
+    {
+
+        $date = $this->createExtDateTime('2004-01-01T10:10:10');
+        $this->assertSame('2004-01-01T10:10:10', $date->iso8601());
+
+        $date = $this->createExtDateTime('2004-01-01T10:10:10+00:00');
+        $this->assertSame('2004-01-01T10:10:10+00:00', $date->iso8601());
+
+        $date = $this->createExtDateTime('2004-01-01T10:10:10+05:00');
+        $this->assertSame('2004-01-01T10:10:10+05:00', $date->iso8601());
+
+        $date = $this->createExtDateTime('2004-01-01T10:10:10-05:00');
+        $this->assertSame('2004-01-01T10:10:10-05:00', $date->iso8601());
+
+
+    }
 }


### PR DESCRIPTION
Sometimes I need to transform my EDTF into ISO 8601 forms for things like SOLR date indexing. I could just do the conversion when I need it, but I thought including it here would be useful.

Also, there was a question about the usefulness of Interval::getStartDate() and Interval::getEndDate(); I find them very useful, especially if it gets me access to the ISO function.