### PR TITLE
Allow nesbot/carbon 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ext-json": "*",
 		"php": "^7.4|^8",
 		"symfony/polyfill-php80": "^1.18.1",
-		"nesbot/carbon": "^2.41"
+		"nesbot/carbon": "^3|^2.41"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.5.2",


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/EDTF/issues/111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened date/time library compatibility to include the latest major version, enabling installations with Carbon v3 in addition to v2.41.
  * Improves dependency resolution and reduces version conflicts during installation and updates.
  * No functional changes to the app; behavior and public interfaces remain the same.
  * No user action required; existing setups continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->