### PR TITLE
ISSUE-113: Increments a year in a Season's end date, if start month > end month

### DIFF
--- a/src/Model/Season.php
+++ b/src/Model/Season.php
@@ -30,7 +30,7 @@ class Season implements EdtfValue, HasPrecision {
 		$this->start = new ExtDate( $year, $startMonth );
 		$endMonth = $this->generateEndMonth();
 		$year = $endMonth < $startMonth ? ($year + 1) : $year;
-		$this->end = new ExtDate( $year, $this->generateEndMonth() );
+		$this->end = new ExtDate( $year, $endMonth );
 	}
 
 	private function generateStartMonth(): int {

--- a/src/Model/Season.php
+++ b/src/Model/Season.php
@@ -11,7 +11,12 @@ use EDTF\PackagePrivate\CoversTrait;
 class Season implements EdtfValue, HasPrecision {
 	use CoversTrait;
 
-	private int $year;
+  /**
+   * The initial year.
+   * A Season could span into a next one.
+   * @var int
+   */
+  private int $year;
 	private int $season;
 
 	private ExtDate $start;
@@ -20,8 +25,10 @@ class Season implements EdtfValue, HasPrecision {
 	public function __construct( int $year, int $season ) {
 		$this->year = $year;
 		$this->season = $season;
-
-		$this->start = new ExtDate( $year, $this->generateStartMonth() );
+		$startMonth = $this->generateStartMonth();
+		$this->start = new ExtDate( $year, $startMonth );
+		$endMonth = $this->generateEndMonth();
+		$year = $endMonth < $startMonth ? ($year + 1) : $year;
 		$this->end = new ExtDate( $year, $this->generateEndMonth() );
 	}
 
@@ -99,7 +106,13 @@ class Season implements EdtfValue, HasPrecision {
 		return $this->start->getMin();
 	}
 
-	public function getYear(): int {
+  /**
+   * Returns the Original Year present in the Season EDTF string definition.
+   * Some seasons can expand to the next year.
+   *
+   * @return int
+   */
+  public function getYear(): int {
 		return $this->year;
 	}
 
@@ -168,6 +181,14 @@ class Season implements EdtfValue, HasPrecision {
 	public function getEndMonth(): int {
 		return $this->end->getMonth();
 	}
+
+  public function getStartYear(): int {
+    return $this->start->getYear();
+  }
+
+  public function getEndYear(): int {
+    return $this->end->getYear();
+  }
 
 	public function precision(): int {
 		return self::PRECISION_SEASON;

--- a/src/Model/Season.php
+++ b/src/Model/Season.php
@@ -15,7 +15,7 @@ class Season implements EdtfValue, HasPrecision {
    * The initial year.
    * A Season could span into a next one.
    * @var int
-  */
+	*/
 	private int $year;
 
 	private int $season;
@@ -183,13 +183,13 @@ class Season implements EdtfValue, HasPrecision {
 		return $this->end->getMonth();
 	}
 
-  public function getStartYear(): int {
-    return $this->start->getYear();
-  }
+	public function getStartYear(): int {
+		return $this->start->getYear();
+	}
 
-  public function getEndYear(): int {
-    return $this->end->getYear();
-  }
+	public function getEndYear(): int {
+		return $this->end->getYear();
+	}
 
 	public function precision(): int {
 		return self::PRECISION_SEASON;

--- a/src/Model/Season.php
+++ b/src/Model/Season.php
@@ -12,10 +12,10 @@ class Season implements EdtfValue, HasPrecision {
 	use CoversTrait;
 
 	/**
-   * The initial year.
-   * A Season could span into a next one.
-   * @var int
-	*/
+	 * The initial year.
+	 * A Season could span into a next one.
+	 * @var int
+	 */
 	private int $year;
 
 	private int $season;
@@ -107,13 +107,13 @@ class Season implements EdtfValue, HasPrecision {
 		return $this->start->getMin();
 	}
 
-  /**
-   * Returns the Original Year present in the Season EDTF string definition.
-   * Some seasons can expand to the next year.
-   *
-   * @return int
-   */
-  public function getYear(): int {
+	/**
+	 * Returns the Original Year present in the Season EDTF string definition.
+	 * Some seasons can expand to the next year.
+	 *
+	 * @return int
+	 */
+	public function getYear(): int {
 		return $this->year;
 	}
 

--- a/src/Model/Season.php
+++ b/src/Model/Season.php
@@ -11,12 +11,13 @@ use EDTF\PackagePrivate\CoversTrait;
 class Season implements EdtfValue, HasPrecision {
 	use CoversTrait;
 
-  /**
+	/**
    * The initial year.
    * A Season could span into a next one.
    * @var int
-   */
-  private int $year;
+  */
+	private int $year;
+
 	private int $season;
 
 	private ExtDate $start;

--- a/tests/Unit/Model/SeasonTest.php
+++ b/tests/Unit/Model/SeasonTest.php
@@ -88,12 +88,13 @@ class SeasonTest extends TestCase {
 		$seasonEnd = Carbon::createFromTimestamp( $season->getMax() );
 
 		// Fetch max/min years from public methods.
-		$seasonStartYearFromMethod = $season->getStartYear();
-		$seasonEndYearFromMethod = $season->getEndYear();
-
-		// start season validation
-		$this->assertSame( $expectedStart->year, $seasonStartYearFromMethod);
-		$this->assertSame( $expectedEnd->year, $seasonEndYearFromMethod);
+		if ($season instanceof Season) {
+			$seasonStartYearFromMethod = $season->getStartYear();
+			$seasonEndYearFromMethod = $season->getEndYear();
+			// start season validation
+			$this->assertSame( $expectedStart->year, $seasonStartYearFromMethod);
+			$this->assertSame( $expectedEnd->year, $seasonEndYearFromMethod);
+		}
 
 		$this->assertSame( $expectedStart->year, $seasonStart->year );
 		$this->assertSame( $expectedStart->month, $seasonStart->month );

--- a/tests/Unit/Model/SeasonTest.php
+++ b/tests/Unit/Model/SeasonTest.php
@@ -16,12 +16,25 @@ use PHPUnit\Framework\TestCase;
 class SeasonTest extends TestCase {
 
 	public function testCreate(): void {
+		// Quarter 1
 		$season = new Season( 2010, 33 );
 		$this->assertSame( 2010, $season->getYear() );
 		$this->assertSame( 33, $season->getSeason() );
 		$this->assertSame( [ 1, 2, 3 ], $season->getMonths() );
 		$this->assertSame( 1, $season->getStartMonth() );
 		$this->assertSame( 3, $season->getEndMonth() );
+		$this->assertSame( 2010, $season->getStartYear() );
+		$this->assertSame( 2010, $season->getEndYear() );
+
+		// Winter spanning into next year.
+		$season = new Season( 1937, 24 );
+		$this->assertSame( 1937, $season->getYear() );
+		$this->assertSame( 24, $season->getSeason() );
+		$this->assertSame( [ 12, 1, 2 ], $season->getMonths() );
+		$this->assertSame( 12, $season->getStartMonth() );
+		$this->assertSame( 2, $season->getEndMonth() );
+		$this->assertSame( 1937, $season->getStartYear() );
+		$this->assertSame( 1938, $season->getEndYear() );
 	}
 
 	public function testSpringValues(): void {
@@ -43,9 +56,9 @@ class SeasonTest extends TestCase {
 	}
 
 	public function testWinterValues(): void {
-		$this->assertSeasonValues( '2010-24', '2010-12-01', '2010-02-28' );
-		$this->assertSeasonValues( '2010-28', '2010-12-01', '2010-02-28' );
-		$this->assertSeasonValues( '2010-32', '2010-12-01', '2010-02-28' );
+		$this->assertSeasonValues( '2010-24', '2010-12-01', '2011-02-28' );
+		$this->assertSeasonValues( '2010-28', '2010-12-01', '2011-02-28' );
+		$this->assertSeasonValues( '2010-32', '2010-12-01', '2011-02-28' );
 	}
 
 	public function testQuarterValues(): void {
@@ -74,14 +87,21 @@ class SeasonTest extends TestCase {
 		$seasonStart = Carbon::createFromTimestamp( $season->getMin() );
 		$seasonEnd = Carbon::createFromTimestamp( $season->getMax() );
 
+		// Fetch max/min years from public methods.
+		$seasonStartYearFromMethod = $season->getStartYear();
+		$seasonEndYearFromMethod = $season->getEndYear();
+
 		// start season validation
+		$this->assertSame( $expectedStart->year, $seasonStartYearFromMethod);
+		$this->assertSame( $expectedEnd->year, $seasonEndYearFromMethod);
+
 		$this->assertSame( $expectedStart->year, $seasonStart->year );
 		$this->assertSame( $expectedStart->month, $seasonStart->month );
 		$this->assertSame( $expectedStart->day, $seasonStart->day );
 
-		// end season validation
 		$this->assertSame( $expectedEnd->year, $seasonEnd->year );
 		$this->assertSame( $expectedEnd->month, $seasonEnd->month );
 		$this->assertSame( $expectedEnd->day, $seasonEnd->day );
+		// end season validation.
 	}
 }


### PR DESCRIPTION
See #113 

Also adds to public methods to fetch those years but keeps the original private $year as-is (used on the constructor) to avoid breaking the contract. Also adds some basic tests (and fixes testWinterValues() expected end dates)

@JeroenDeDauw I kept the private $year property (which could be deceiving if someone trusts blindly that getYear() covers start and end always, because humanizer needs/uses it. But I added a comment and two public methods for direct access to start/end years + tests.

All tests are passing. Happy to change code/amend/improve (sorry for the many extra pulls, had forgotten you all use tabs!). Thanks a lot